### PR TITLE
Add updated test vector text files

### DIFF
--- a/output_add_info_be128.txt
+++ b/output_add_info_be128.txt
@@ -11,16 +11,16 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 0
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 0
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
-MSG =                           
-PADDED_AAD_and_MSG =            
+AAD =
+MSG =
+PADDED_AAD_and_MSG =
 LENBLK =                        00000000000000000000000000000000
 
 Computing POLYVAL on a
@@ -29,12 +29,12 @@ POLYVAL =                       00000000000000000000000000000000
 POLYVAL_xor_NONCE  =            03000000000000000000000000000000
 with MSBit cleared =            03000000000000000000000000000000
 TAG =                           fabfd7964630aa6128ee6269f061f08b
-AAD =                           
-CT  =                           
+AAD =
+CT  =
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -63,14 +63,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           0100000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000004000000000000000
@@ -81,12 +81,12 @@ POLYVAL =                       04000000000000809100000000283b1c
 POLYVAL_xor_NONCE  =            07000000000000809100000000283b1c
 with MSBit cleared =            07000000000000809100000000283b1c
 TAG =                           5537355b0a4f4cb05ce77d1b815d7299
-AAD =                           
-CT  =                           3b0f5baabe526e9f
+AAD =
+CT  =                           9c9ba00f9686d157
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -102,7 +102,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000000a4f4cb05ce77d1b815d7299
+                                5537355b0a4f4cb05ce77d1b815d7299
 
 
 
@@ -116,14 +116,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           010000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000006000000000000000
@@ -134,12 +134,12 @@ POLYVAL =                       0400000000000040d900000000283b1c
 POLYVAL_xor_NONCE  =            0700000000000040d900000000283b1c
 with MSBit cleared =            0700000000000040d900000000283b1c
 TAG =                           dd55830c690eadd7fd2155b3615470bd
-AAD =                           
-CT  =                           9391b4122fccfecb60ec40ab
+AAD =
+CT  =                           af21532e06416ab7a902710e
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -155,7 +155,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000690eadd7fd2155b3615470bd
+                                dd55830c690eadd7fd2155b3615470bd
 
 
 
@@ -169,14 +169,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000008000000000000000
@@ -187,12 +187,12 @@ POLYVAL =                       04000000000000002301000000283b1c
 POLYVAL_xor_NONCE  =            07000000000000002301000000283b1c
 with MSBit cleared =            07000000000000002301000000283b1c
 TAG =                           147650d36f064f6b5dbbe8f04077d903
-AAD =                           
-CT  =                           565e4a931280ecdece8620abcf90b65e
+AAD =
+CT  =                           a42b0ef844bd99fb2658e7a93fc8159c
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -208,7 +208,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000006f064f6b5dbbe8f04077d983
+                                147650d36f064f6b5dbbe8f04077d983
 
 
 
@@ -222,14 +222,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
@@ -242,13 +242,13 @@ POLYVAL =                       010000000000000046020000f0507615
 POLYVAL_xor_NONCE  =            020000000000000046020000f0507615
 with MSBit cleared =            020000000000000046020000f0507615
 TAG =                           78a50cb3f901ee38c588f6662d785a24
-AAD =                           
-CT  =                           9b1d2ba7d2d3a02efeecc18d03be2b56
-                                1753b147ae642183f2c4bbd72e4ed8e1
+AAD =
+CT  =                           ebb355fb913c781bee9ea36ff920193f
+                                80c8aa6d0abd197f039be49616f62e4f
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -264,8 +264,8 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000f901ee38c588f6662d785aa4
-                                01000000f901ee38c588f6662d785aa4
+                                78a50cb3f901ee38c588f6662d785aa4
+                                79a50cb3f901ee38c588f6662d785aa4
 
 
 
@@ -279,14 +279,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 48
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 3
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
                                 03000000000000000000000000000000
@@ -301,14 +301,14 @@ POLYVAL =                       0e00000000000000650300203e788f7f
 POLYVAL_xor_NONCE  =            0d00000000000000650300203e788f7f
 with MSBit cleared =            0d00000000000000650300203e788f7f
 TAG =                           a75aa62b704e826d984a72184e370598
-AAD =                           
-CT  =                           dcc8d2f2c0e30b565f5d3ef58bf6638f
-                                f50e8909ced008e0515b79f7c8c3d1f5
-                                8ec1bb09177133b4cd1b375911d81579
+AAD =
+CT  =                           5cf01ee258867977c0dd93dc33c9ccaf
+                                fcf088d95bb3d17221cfb58f2cd14703
+                                068463f2c0a18185cd745bcaf7b72ed5
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -324,9 +324,9 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000704e826d984a72184e370598
-                                01000000704e826d984a72184e370598
-                                02000000704e826d984a72184e370598
+                                a75aa62b704e826d984a72184e370598
+                                a85aa62b704e826d984a72184e370598
+                                a95aa62b704e826d984a72184e370598
 
 
 
@@ -340,14 +340,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 64
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 4
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
                                 03000000000000000000000000000000
@@ -364,15 +364,15 @@ POLYVAL =                       0f000000000000008c04c04c63ad584f
 POLYVAL_xor_NONCE  =            0c000000000000008c04c04c63ad584f
 with MSBit cleared =            0c000000000000008c04c04c63ad584f
 TAG =                           d7f4efe2f6c72e3b8df168cab6b790ab
-AAD =                           
-CT  =                           472d6309563c74b6d5497145e929725a
-                                ab08979e6c4fc72c30c2e3a1ce568b94
-                                92e1b0351167937ee2faae79d40af93e
-                                24eee045fdab1b2040440632f1a34433
+AAD =
+CT  =                           442acedd0154ad46741b42ea12bd76b6
+                                6f3f13e79c89e88fc0d0651ab70aa474
+                                226f538c660d95f0867dc65d7c0b0af6
+                                17339e1db42294b52b4ab4fc06234769
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -388,10 +388,10 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000f6c72e3b8df168cab6b790ab
-                                01000000f6c72e3b8df168cab6b790ab
-                                02000000f6c72e3b8df168cab6b790ab
-                                03000000f6c72e3b8df168cab6b790ab
+                                d7f4efe2f6c72e3b8df168cab6b790ab
+                                d8f4efe2f6c72e3b8df168cab6b790ab
+                                d9f4efe2f6c72e3b8df168cab6b790ab
+                                daf4efe2f6c72e3b8df168cab6b790ab
 
 
 
@@ -405,7 +405,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -425,11 +425,11 @@ POLYVAL_xor_NONCE  =            100000000000008091000000f0501631
 with MSBit cleared =            100000000000008091000000f0501631
 TAG =                           633c11b2eee1f65be0e3f1e0c824c5e0
 AAD =                           01
-CT  =                           5adcda74026afb99
+CT  =                           b3aa6df500d38f0f
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -445,7 +445,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000eee1f65be0e3f1e0c824c5e0
+                                633c11b2eee1f65be0e3f1e0c824c5e0
 
 
 
@@ -459,7 +459,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -479,11 +479,11 @@ POLYVAL_xor_NONCE  =            1000000000000040d9000000f0501631
 with MSBit cleared =            1000000000000040d9000000f0501631
 TAG =                           f229e75b2c4c3048fc70f163c9aefe0d
 AAD =                           01
-CT  =                           b4fabbadb27257bbe8b807d5
+CT  =                           b5bea0352fbe77e5dc84aac4
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -499,7 +499,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000002c4c3048fc70f163c9aefe8d
+                                f229e75b2c4c3048fc70f163c9aefe8d
 
 
 
@@ -513,7 +513,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -533,11 +533,11 @@ POLYVAL_xor_NONCE  =            100000000000000023010000f0501631
 with MSBit cleared =            100000000000000023010000f0501631
 TAG =                           cfb5aa16cdd9d39acc5d99b6eee2c6fc
 AAD =                           01
-CT  =                           dce7c7cd4d1060fdc663b9fe8de25385
+CT  =                           86f7d1853ecc302a598c0e054d917a9c
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -553,7 +553,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000cdd9d39acc5d99b6eee2c6fc
+                                cfb5aa16cdd9d39acc5d99b6eee2c6fc
 
 
 
@@ -567,7 +567,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -589,12 +589,12 @@ POLYVAL_xor_NONCE  =            1f00000000000000460200203e78ef5b
 with MSBit cleared =            1f00000000000000460200203e78ef5b
 TAG =                           8df5606f057468e4b38e89736255ad2d
 AAD =                           01
-CT  =                           c6d3098e12ac653520764cbccdb90655
-                                b3d91bf034f7549d5f775fca5d6ad34f
+CT  =                           a58e74cc44de5637d02d800119da54c1
+                                df3f9f8a1930953819a7d8d1d76f10c0
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -610,8 +610,8 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000057468e4b38e89736255adad
-                                01000000057468e4b38e89736255adad
+                                8df5606f057468e4b38e89736255adad
+                                8ef5606f057468e4b38e89736255adad
 
 
 
@@ -625,7 +625,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 48
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 3
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -649,13 +649,13 @@ POLYVAL_xor_NONCE  =            1e000000000000006503c04c63ad386b
 with MSBit cleared =            1e000000000000006503c04c63ad386b
 TAG =                           b52274e14d6111c74edf5d95855256a2
 AAD =                           01
-CT  =                           186abbbe486294281b1514c11c240e6a
-                                4d959a1ac6da46e5b83bbe2d3d37de44
-                                ab009bb885b5c0bf83db80b651c06e74
+CT  =                           9ceaefd1522cc88b1a9dde5f86253b70
+                                309a25c160bb37dc677ed126ce23e7ab
+                                31ea937735d6353af5cf02de8ff5b2ff
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -671,9 +671,9 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000004d6111c74edf5d95855256a2
-                                010000004d6111c74edf5d95855256a2
-                                020000004d6111c74edf5d95855256a2
+                                b52274e14d6111c74edf5d95855256a2
+                                b62274e14d6111c74edf5d95855256a2
+                                b72274e14d6111c74edf5d95855256a2
 
 
 
@@ -687,7 +687,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 64
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 4
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -713,14 +713,14 @@ POLYVAL_xor_NONCE  =            18000000000000008c841a01712a376e
 with MSBit cleared =            18000000000000008c841a01712a376e
 TAG =                           668fc00b6b40b4bb0c8d6cdb9730358d
 AAD =                           01
-CT  =                           499ec09c83c2b79cf6b219e6b79ec81c
-                                7c7b572c8a04b322094ec011e7003ded
-                                388627f831ee79bd3df5db27f648125a
-                                fbfe2774388c34bb652b866ca84bdcd8
+CT  =                           457e976e1f62be30a2bfb8d8801b7282
+                                8dd5349701b0f93007bcae4c2daed6fa
+                                d91c3ae1751edaf54abf47bb1f0608dd
+                                2961c86e7860dcb75336be054c1ad6cf
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -736,10 +736,10 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000006b40b4bb0c8d6cdb9730358d
-                                010000006b40b4bb0c8d6cdb9730358d
-                                020000006b40b4bb0c8d6cdb9730358d
-                                030000006b40b4bb0c8d6cdb9730358d
+                                668fc00b6b40b4bb0c8d6cdb9730358d
+                                678fc00b6b40b4bb0c8d6cdb9730358d
+                                688fc00b6b40b4bb0c8d6cdb9730358d
+                                698fc00b6b40b4bb0c8d6cdb9730358d
 
 
 
@@ -753,7 +753,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -773,11 +773,11 @@ POLYVAL_xor_NONCE  =            db000000000000c048000000f050f665
 with MSBit cleared =            db000000000000c048000000f050f665
 TAG =                           488346eaebe2d64ffa58e0fa82f8cd43
 AAD =                           010000000000000000000000
-CT  =                           7d5240be
+CT  =                           c2b96956
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -793,7 +793,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000ebe2d64ffa58e0fa82f8cdc3
+                                488346eaebe2d64ffa58e0fa82f8cdc3
 
 
 
@@ -807,7 +807,7 @@ padded_AAD_byte_len = 32
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 2
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -832,12 +832,12 @@ with MSBit cleared =            0b010000000000c06b01c04c63ad9807
 TAG =                           d010794cfdbbc65ef641b8ccb9c2dda3
 AAD =                           01000000000000000000000000000000
                                 0200
-CT  =                           6d98c309d4f472480c5b1389e83569e5
-                                217ddb9c
+CT  =                           348bf14b0fe2f8a2c3e843429df6276c
+                                c0e5e688
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -853,8 +853,8 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000fdbbc65ef641b8ccb9c2dda3
-                                01000000fdbbc65ef641b8ccb9c2dda3
+                                d010794cfdbbc65ef641b8ccb9c2dda3
+                                d110794cfdbbc65ef641b8ccb9c2dda3
 
 
 
@@ -868,7 +868,7 @@ padded_AAD_byte_len = 32
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 2
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -893,12 +893,12 @@ with MSBit cleared =            67010000000000600701c04c63add85e
 TAG =                           98e16515942fb8ff9ef108e7ce53a963
 AAD =                           01000000000000000000000000000000
                                 02000000
-CT  =                           4649087685b01b476bd3420f36ca67d3
-                                b18b
+CT  =                           f803a8b63ffa8c44a391c7e4ccc31e61
+                                79d1
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -914,8 +914,8 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000942fb8ff9ef108e7ce53a9e3
-                                01000000942fb8ff9ef108e7ce53a9e3
+                                98e16515942fb8ff9ef108e7ce53a9e3
+                                99e16515942fb8ff9ef108e7ce53a9e3
 
 
 
@@ -929,16 +929,16 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 0
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 0
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
-MSG =                           
-PADDED_AAD_and_MSG =            
+AAD =
+MSG =
+PADDED_AAD_and_MSG =
 LENBLK =                        00000000000000000000000000000000
 
 Computing POLYVAL on a
@@ -947,12 +947,21 @@ POLYVAL =                       00000000000000000000000000000000
 POLYVAL_xor_NONCE  =            03000000000000000000000000000000
 with MSBit cleared =            03000000000000000000000000000000
 TAG =                           fabfd7964630aa6128ee6269f061f08b
-AAD =                           
-CT  =                           
+AAD =
+CT  =
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =
+
+TAG' =                          fabfd7964630aa6128ee6269f061f08b
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -981,14 +990,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           0100000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000004000000000000000
@@ -999,12 +1008,21 @@ POLYVAL =                       04000000000000809100000000283b1c
 POLYVAL_xor_NONCE  =            07000000000000809100000000283b1c
 with MSBit cleared =            07000000000000809100000000283b1c
 TAG =                           5537355b0a4f4cb05ce77d1b815d7299
-AAD =                           
-CT  =                           3b0f5baabe526e9f
+AAD =
+CT  =                           9c9ba00f9686d157
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 0100000000000000
+
+TAG' =                          5537355b0a4f4cb05ce77d1b815d7299
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1020,7 +1038,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000000a4f4cb05ce77d1b815d7299
+                                5537355b0a4f4cb05ce77d1b815d7299
 
 
 
@@ -1034,14 +1052,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           010000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000006000000000000000
@@ -1052,12 +1070,21 @@ POLYVAL =                       0400000000000040d900000000283b1c
 POLYVAL_xor_NONCE  =            0700000000000040d900000000283b1c
 with MSBit cleared =            0700000000000040d900000000283b1c
 TAG =                           dd55830c690eadd7fd2155b3615470bd
-AAD =                           
-CT  =                           9391b4122fccfecb60ec40ab
+AAD =
+CT  =                           af21532e06416ab7a902710e
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 010000000000000000000000
+
+TAG' =                          dd55830c690eadd7fd2155b3615470bd
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1073,7 +1100,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000690eadd7fd2155b3615470bd
+                                dd55830c690eadd7fd2155b3615470bd
 
 
 
@@ -1087,14 +1114,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000008000000000000000
@@ -1105,12 +1132,21 @@ POLYVAL =                       04000000000000002301000000283b1c
 POLYVAL_xor_NONCE  =            07000000000000002301000000283b1c
 with MSBit cleared =            07000000000000002301000000283b1c
 TAG =                           147650d36f064f6b5dbbe8f04077d903
-AAD =                           
-CT  =                           565e4a931280ecdece8620abcf90b65e
+AAD =
+CT  =                           a42b0ef844bd99fb2658e7a93fc8159c
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 01000000000000000000000000000000
+
+TAG' =                          147650d36f064f6b5dbbe8f04077d903
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1126,7 +1162,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000006f064f6b5dbbe8f04077d983
+                                147650d36f064f6b5dbbe8f04077d983
 
 
 
@@ -1140,14 +1176,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
@@ -1160,13 +1196,23 @@ POLYVAL =                       010000000000000046020000f0507615
 POLYVAL_xor_NONCE  =            020000000000000046020000f0507615
 with MSBit cleared =            020000000000000046020000f0507615
 TAG =                           78a50cb3f901ee38c588f6662d785a24
-AAD =                           
-CT  =                           9b1d2ba7d2d3a02efeecc18d03be2b56
-                                1753b147ae642183f2c4bbd72e4ed8e1
+AAD =
+CT  =                           ebb355fb913c781bee9ea36ff920193f
+                                80c8aa6d0abd197f039be49616f62e4f
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 01000000000000000000000000000000
+                                02000000000000000000000000000000
+
+TAG' =                          78a50cb3f901ee38c588f6662d785a24
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1182,8 +1228,8 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000f901ee38c588f6662d785aa4
-                                01000000f901ee38c588f6662d785aa4
+                                78a50cb3f901ee38c588f6662d785aa4
+                                79a50cb3f901ee38c588f6662d785aa4
 
 
 
@@ -1197,14 +1243,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 48
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 3
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
                                 03000000000000000000000000000000
@@ -1219,14 +1265,25 @@ POLYVAL =                       0e00000000000000650300203e788f7f
 POLYVAL_xor_NONCE  =            0d00000000000000650300203e788f7f
 with MSBit cleared =            0d00000000000000650300203e788f7f
 TAG =                           a75aa62b704e826d984a72184e370598
-AAD =                           
-CT  =                           dcc8d2f2c0e30b565f5d3ef58bf6638f
-                                f50e8909ced008e0515b79f7c8c3d1f5
-                                8ec1bb09177133b4cd1b375911d81579
+AAD =
+CT  =                           5cf01ee258867977c0dd93dc33c9ccaf
+                                fcf088d95bb3d17221cfb58f2cd14703
+                                068463f2c0a18185cd745bcaf7b72ed5
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 01000000000000000000000000000000
+                                02000000000000000000000000000000
+                                03000000000000000000000000000000
+
+TAG' =                          a75aa62b704e826d984a72184e370598
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1242,9 +1299,9 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000704e826d984a72184e370598
-                                01000000704e826d984a72184e370598
-                                02000000704e826d984a72184e370598
+                                a75aa62b704e826d984a72184e370598
+                                a85aa62b704e826d984a72184e370598
+                                a95aa62b704e826d984a72184e370598
 
 
 
@@ -1258,14 +1315,14 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 64
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 4
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
 K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
                                 03000000000000000000000000000000
@@ -1282,15 +1339,27 @@ POLYVAL =                       0f000000000000008c04c04c63ad584f
 POLYVAL_xor_NONCE  =            0c000000000000008c04c04c63ad584f
 with MSBit cleared =            0c000000000000008c04c04c63ad584f
 TAG =                           d7f4efe2f6c72e3b8df168cab6b790ab
-AAD =                           
-CT  =                           472d6309563c74b6d5497145e929725a
-                                ab08979e6c4fc72c30c2e3a1ce568b94
-                                92e1b0351167937ee2faae79d40af93e
-                                24eee045fdab1b2040440632f1a34433
+AAD =
+CT  =                           442acedd0154ad46741b42ea12bd76b6
+                                6f3f13e79c89e88fc0d0651ab70aa474
+                                226f538c660d95f0867dc65d7c0b0af6
+                                17339e1db42294b52b4ab4fc06234769
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 01000000000000000000000000000000
+                                02000000000000000000000000000000
+                                03000000000000000000000000000000
+                                04000000000000000000000000000000
+
+TAG' =                          d7f4efe2f6c72e3b8df168cab6b790ab
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1306,10 +1375,10 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000f6c72e3b8df168cab6b790ab
-                                01000000f6c72e3b8df168cab6b790ab
-                                02000000f6c72e3b8df168cab6b790ab
-                                03000000f6c72e3b8df168cab6b790ab
+                                d7f4efe2f6c72e3b8df168cab6b790ab
+                                d8f4efe2f6c72e3b8df168cab6b790ab
+                                d9f4efe2f6c72e3b8df168cab6b790ab
+                                daf4efe2f6c72e3b8df168cab6b790ab
 
 
 
@@ -1323,7 +1392,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1343,11 +1412,20 @@ POLYVAL_xor_NONCE  =            100000000000008091000000f0501631
 with MSBit cleared =            100000000000008091000000f0501631
 TAG =                           633c11b2eee1f65be0e3f1e0c824c5e0
 AAD =                           01
-CT  =                           5adcda74026afb99
+CT  =                           b3aa6df500d38f0f
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 0200000000000000
+
+TAG' =                          633c11b2eee1f65be0e3f1e0c824c5e0
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1363,7 +1441,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000eee1f65be0e3f1e0c824c5e0
+                                633c11b2eee1f65be0e3f1e0c824c5e0
 
 
 
@@ -1377,7 +1455,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1397,11 +1475,20 @@ POLYVAL_xor_NONCE  =            1000000000000040d9000000f0501631
 with MSBit cleared =            1000000000000040d9000000f0501631
 TAG =                           f229e75b2c4c3048fc70f163c9aefe0d
 AAD =                           01
-CT  =                           b4fabbadb27257bbe8b807d5
+CT  =                           b5bea0352fbe77e5dc84aac4
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 020000000000000000000000
+
+TAG' =                          f229e75b2c4c3048fc70f163c9aefe0d
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1417,7 +1504,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000002c4c3048fc70f163c9aefe8d
+                                f229e75b2c4c3048fc70f163c9aefe8d
 
 
 
@@ -1431,7 +1518,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1451,11 +1538,20 @@ POLYVAL_xor_NONCE  =            100000000000000023010000f0501631
 with MSBit cleared =            100000000000000023010000f0501631
 TAG =                           cfb5aa16cdd9d39acc5d99b6eee2c6fc
 AAD =                           01
-CT  =                           dce7c7cd4d1060fdc663b9fe8de25385
+CT  =                           86f7d1853ecc302a598c0e054d917a9c
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 02000000000000000000000000000000
+
+TAG' =                          cfb5aa16cdd9d39acc5d99b6eee2c6fc
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1471,7 +1567,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000cdd9d39acc5d99b6eee2c6fc
+                                cfb5aa16cdd9d39acc5d99b6eee2c6fc
 
 
 
@@ -1485,7 +1581,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1507,12 +1603,22 @@ POLYVAL_xor_NONCE  =            1f00000000000000460200203e78ef5b
 with MSBit cleared =            1f00000000000000460200203e78ef5b
 TAG =                           8df5606f057468e4b38e89736255ad2d
 AAD =                           01
-CT  =                           c6d3098e12ac653520764cbccdb90655
-                                b3d91bf034f7549d5f775fca5d6ad34f
+CT  =                           a58e74cc44de5637d02d800119da54c1
+                                df3f9f8a1930953819a7d8d1d76f10c0
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 02000000000000000000000000000000
+                                03000000000000000000000000000000
+
+TAG' =                          8df5606f057468e4b38e89736255ad2d
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1528,8 +1634,8 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000057468e4b38e89736255adad
-                                01000000057468e4b38e89736255adad
+                                8df5606f057468e4b38e89736255adad
+                                8ef5606f057468e4b38e89736255adad
 
 
 
@@ -1543,7 +1649,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 48
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 3
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1567,13 +1673,24 @@ POLYVAL_xor_NONCE  =            1e000000000000006503c04c63ad386b
 with MSBit cleared =            1e000000000000006503c04c63ad386b
 TAG =                           b52274e14d6111c74edf5d95855256a2
 AAD =                           01
-CT  =                           186abbbe486294281b1514c11c240e6a
-                                4d959a1ac6da46e5b83bbe2d3d37de44
-                                ab009bb885b5c0bf83db80b651c06e74
+CT  =                           9ceaefd1522cc88b1a9dde5f86253b70
+                                309a25c160bb37dc677ed126ce23e7ab
+                                31ea937735d6353af5cf02de8ff5b2ff
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 02000000000000000000000000000000
+                                03000000000000000000000000000000
+                                04000000000000000000000000000000
+
+TAG' =                          b52274e14d6111c74edf5d95855256a2
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1589,9 +1706,9 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000004d6111c74edf5d95855256a2
-                                010000004d6111c74edf5d95855256a2
-                                020000004d6111c74edf5d95855256a2
+                                b52274e14d6111c74edf5d95855256a2
+                                b62274e14d6111c74edf5d95855256a2
+                                b72274e14d6111c74edf5d95855256a2
 
 
 
@@ -1605,7 +1722,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 64
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 4
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1631,14 +1748,26 @@ POLYVAL_xor_NONCE  =            18000000000000008c841a01712a376e
 with MSBit cleared =            18000000000000008c841a01712a376e
 TAG =                           668fc00b6b40b4bb0c8d6cdb9730358d
 AAD =                           01
-CT  =                           499ec09c83c2b79cf6b219e6b79ec81c
-                                7c7b572c8a04b322094ec011e7003ded
-                                388627f831ee79bd3df5db27f648125a
-                                fbfe2774388c34bb652b866ca84bdcd8
+CT  =                           457e976e1f62be30a2bfb8d8801b7282
+                                8dd5349701b0f93007bcae4c2daed6fa
+                                d91c3ae1751edaf54abf47bb1f0608dd
+                                2961c86e7860dcb75336be054c1ad6cf
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 02000000000000000000000000000000
+                                03000000000000000000000000000000
+                                04000000000000000000000000000000
+                                05000000000000000000000000000000
+
+TAG' =                          668fc00b6b40b4bb0c8d6cdb9730358d
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1654,10 +1783,10 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000006b40b4bb0c8d6cdb9730358d
-                                010000006b40b4bb0c8d6cdb9730358d
-                                020000006b40b4bb0c8d6cdb9730358d
-                                030000006b40b4bb0c8d6cdb9730358d
+                                668fc00b6b40b4bb0c8d6cdb9730358d
+                                678fc00b6b40b4bb0c8d6cdb9730358d
+                                688fc00b6b40b4bb0c8d6cdb9730358d
+                                698fc00b6b40b4bb0c8d6cdb9730358d
 
 
 
@@ -1671,7 +1800,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1691,11 +1820,20 @@ POLYVAL_xor_NONCE  =            db000000000000c048000000f050f665
 with MSBit cleared =            db000000000000c048000000f050f665
 TAG =                           488346eaebe2d64ffa58e0fa82f8cd43
 AAD =                           010000000000000000000000
-CT  =                           7d5240be
+CT  =                           c2b96956
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 02000000
+
+TAG' =                          488346eaebe2d64ffa58e0fa82f8cd43
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1711,7 +1849,7 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000ebe2d64ffa58e0fa82f8cdc3
+                                488346eaebe2d64ffa58e0fa82f8cdc3
 
 
 
@@ -1725,7 +1863,7 @@ padded_AAD_byte_len = 32
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 2
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1750,12 +1888,22 @@ with MSBit cleared =            0b010000000000c06b01c04c63ad9807
 TAG =                           d010794cfdbbc65ef641b8ccb9c2dda3
 AAD =                           01000000000000000000000000000000
                                 0200
-CT  =                           6d98c309d4f472480c5b1389e83569e5
-                                217ddb9c
+CT  =                           348bf14b0fe2f8a2c3e843429df6276c
+                                c0e5e688
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 03000000000000000000000000000000
+                                04000000
+
+TAG' =                          d010794cfdbbc65ef641b8ccb9c2dda3
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1771,8 +1919,8 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000fdbbc65ef641b8ccb9c2dda3
-                                01000000fdbbc65ef641b8ccb9c2dda3
+                                d010794cfdbbc65ef641b8ccb9c2dda3
+                                d110794cfdbbc65ef641b8ccb9c2dda3
 
 
 
@@ -1786,7 +1934,7 @@ padded_AAD_byte_len = 32
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 2
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1811,12 +1959,22 @@ with MSBit cleared =            67010000000000600701c04c63add85e
 TAG =                           98e16515942fb8ff9ef108e7ce53a963
 AAD =                           01000000000000000000000000000000
                                 02000000
-CT  =                           4649087685b01b476bd3420f36ca67d3
-                                b18b
+CT  =                           f803a8b63ffa8c44a391c7e4ccc31e61
+                                79d1
 Encryption_Key=                 57d4b7aec8de993e30a6861b61e6ce4e
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 03000000000000000000000000000000
+                                0400
+
+TAG' =                          98e16515942fb8ff9ef108e7ce53a963
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
 KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
                                 d85f98411081017f2027876441c1492a
@@ -1832,5 +1990,5 @@ KEY_SCHEDULE (Encryption_Key)   57d4b7aec8de993e30a6861b61e6ce4e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000942fb8ff9ef108e7ce53a9e3
-                                01000000942fb8ff9ef108e7ce53a9e3
+                                98e16515942fb8ff9ef108e7ce53a9e3
+                                99e16515942fb8ff9ef108e7ce53a9e3

--- a/output_add_info_be256.txt
+++ b/output_add_info_be256.txt
@@ -11,7 +11,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 0
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 0
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -19,9 +19,9 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
-MSG =                           
-PADDED_AAD_and_MSG =            
+AAD =
+MSG =
+PADDED_AAD_and_MSG =
 LENBLK =                        00000000000000000000000000000000
 
 Computing POLYVAL on a
@@ -29,30 +29,30 @@ buffer of 0 blocks + LENBLK.
 POLYVAL =                       00000000000000000000000000000000
 POLYVAL_xor_NONCE  =            03000000000000000000000000000000
 with MSBit cleared =            03000000000000000000000000000000
-TAG =                           de1a5fcd85a5217d91d8b349ab9cd224
-AAD =                           
-CT  =                           
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           9f32298b78fb3a5e42a41f9ec395a8a0
+AAD =
+CT  =
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
@@ -69,7 +69,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -77,7 +77,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           0100000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000004000000000000000
@@ -87,34 +87,34 @@ buffer of 1 blocks + LENBLK.
 POLYVAL =                       04000000000000809100000000283b1c
 POLYVAL_xor_NONCE  =            07000000000000809100000000283b1c
 with MSBit cleared =            07000000000000809100000000283b1c
-TAG =                           90d1e4ad87f53fbf3eb26c066193fdf3
-AAD =                           
-CT  =                           4b0619edd74c6a09
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           ca9daafe8fe6f1f97d5d37780af4d423
+AAD =
+CT  =                           403c53d07ec9ff2c
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                0000000087f53fbf3eb26c066193fdf3
+                                ca9daafe8fe6f1f97d5d37780af4d4a3
 
 
 
@@ -128,7 +128,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -136,7 +136,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           010000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000006000000000000000
@@ -146,34 +146,34 @@ buffer of 1 blocks + LENBLK.
 POLYVAL =                       0400000000000040d900000000283b1c
 POLYVAL_xor_NONCE  =            0700000000000040d900000000283b1c
 with MSBit cleared =            0700000000000040d900000000283b1c
-TAG =                           a42c36bcd7dd95273c5ded5a5ab0a8fc
-AAD =                           
-CT  =                           ea410b6727fe50357dc2c9f9
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           675861642d6f7c42973d470843868600
+AAD =
+CT  =                           0a5bcaa698b9cc0bc78383cf
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000d7dd95273c5ded5a5ab0a8fc
+                                675861642d6f7c42973d470843868680
 
 
 
@@ -187,7 +187,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -195,7 +195,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000008000000000000000
@@ -205,34 +205,34 @@ buffer of 1 blocks + LENBLK.
 POLYVAL =                       04000000000000002301000000283b1c
 POLYVAL_xor_NONCE  =            07000000000000002301000000283b1c
 with MSBit cleared =            07000000000000002301000000283b1c
-TAG =                           a86f26245dea30d23ec045223ef5851e
-AAD =                           
-CT  =                           d5d6c0782d45de97a027156334229387
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           255656d6213ddf996629d0c9db7c6332
+AAD =
+CT  =                           dfde1d2f762281c138f9d6d09203a270
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000005dea30d23ec045223ef5859e
+                                255656d6213ddf996629d0c9db7c63b2
 
 
 
@@ -246,7 +246,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -254,7 +254,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
@@ -266,36 +266,36 @@ buffer of 2 blocks + LENBLK.
 POLYVAL =                       010000000000000046020000f0507615
 POLYVAL_xor_NONCE  =            020000000000000046020000f0507615
 with MSBit cleared =            020000000000000046020000f0507615
-TAG =                           ac78c482d3499b26ae97bf353c2c1bdb
-AAD =                           
-CT  =                           cac82890d7f5a8330fa2f0f03701901a
-                                ed8a98666b42f74cc1887bd18964cf37
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           796e2bdd844cff0aac06f4b85a36d66b
+AAD =
+CT  =                           c680d1f9a3f2807ce9debce4bf670a98
+                                680619480f725d06ed91dbcbad65d07a
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000d3499b26ae97bf353c2c1bdb
-                                01000000d3499b26ae97bf353c2c1bdb
+                                796e2bdd844cff0aac06f4b85a36d6eb
+                                7a6e2bdd844cff0aac06f4b85a36d6eb
 
 
 
@@ -309,7 +309,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 48
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 3
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -317,7 +317,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
                                 03000000000000000000000000000000
@@ -331,38 +331,38 @@ buffer of 3 blocks + LENBLK.
 POLYVAL =                       0e00000000000000650300203e788f7f
 POLYVAL_xor_NONCE  =            0d00000000000000650300203e788f7f
 with MSBit cleared =            0d00000000000000650300203e788f7f
-TAG =                           d47a0a762c2dea133c87aea50fb1c1b3
-AAD =                           
-CT  =                           bd562c8f8bbde467149c17a3f316fd2c
-                                8859c748760332d3296a5b233c4059e3
-                                e70a042dfc2b1812f484801a184b23ae
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           0457372a01c505a8718751a8f4c07958
+AAD =
+CT  =                           f5e1b0e6f6113e5d4a87ff54d0c6994e
+                                d1d702f63a63c9f132a7317bdb085dd8
+                                856fba3e70f5ebe2857de62946bd984b
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000002c2dea133c87aea50fb1c1b3
-                                010000002c2dea133c87aea50fb1c1b3
-                                020000002c2dea133c87aea50fb1c1b3
+                                0457372a01c505a8718751a8f4c079d8
+                                0557372a01c505a8718751a8f4c079d8
+                                0657372a01c505a8718751a8f4c079d8
 
 
 
@@ -376,7 +376,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 64
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 4
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -384,7 +384,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
                                 03000000000000000000000000000000
@@ -400,40 +400,40 @@ buffer of 4 blocks + LENBLK.
 POLYVAL =                       0f000000000000008c04c04c63ad584f
 POLYVAL_xor_NONCE  =            0c000000000000008c04c04c63ad584f
 with MSBit cleared =            0c000000000000008c04c04c63ad584f
-TAG =                           15e4bd316b19caa3a3493a81a3e4153c
-AAD =                           
-CT  =                           d53e727defb0fe560c87f405ab19b1a2
-                                6fd85249324b974564c477b2eb4d4162
-                                943fa821946537d507e0713dcc556075
-                                220130acb5f3daa8dd46ee9af3b36642
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           0b188a792d0a940e66f50e37bf7f9810
+AAD =
+CT  =                           f32c3b7315f699ee449b3709fbd109fd
+                                c1726c48a8c48c5b19268372bc83919f
+                                9a717c2b7b042d33a75e4d0806c05f63
+                                5ad443dc419749efe8c4dec48f6d4254
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000006b19caa3a3493a81a3e415bc
-                                010000006b19caa3a3493a81a3e415bc
-                                020000006b19caa3a3493a81a3e415bc
-                                030000006b19caa3a3493a81a3e415bc
+                                0b188a792d0a940e66f50e37bf7f9890
+                                0c188a792d0a940e66f50e37bf7f9890
+                                0d188a792d0a940e66f50e37bf7f9890
+                                0e188a792d0a940e66f50e37bf7f9890
 
 
 
@@ -447,7 +447,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -466,34 +466,34 @@ buffer of 2 blocks + LENBLK.
 POLYVAL =                       130000000000008091000000f0501631
 POLYVAL_xor_NONCE  =            100000000000008091000000f0501631
 with MSBit cleared =            100000000000008091000000f0501631
-TAG =                           4cac1deb89734986b5f0546c661932e9
+TAG =                           6bc14bd99e1dc3de41371ee4012d84be
 AAD =                           01
-CT  =                           8e5a22875d5d692e
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           7b10160344fec6cb
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                0000000089734986b5f0546c661932e9
+                                6bc14bd99e1dc3de41371ee4012d84be
 
 
 
@@ -507,7 +507,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -526,34 +526,34 @@ buffer of 2 blocks + LENBLK.
 POLYVAL =                       1300000000000040d9000000f0501631
 POLYVAL_xor_NONCE  =            1000000000000040d9000000f0501631
 with MSBit cleared =            1000000000000040d9000000f0501631
-TAG =                           42794bd56cd0b78ebdad8dc2c2c11720
+TAG =                           0707868473db0caa87ea08f1c44352c0
 AAD =                           01
-CT  =                           ed921994f8d27aad941bfb6f
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           75ffe5c8403db5fb479bc58b
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000006cd0b78ebdad8dc2c2c117a0
+                                0707868473db0caa87ea08f1c44352c0
 
 
 
@@ -567,7 +567,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -586,34 +586,34 @@ buffer of 2 blocks + LENBLK.
 POLYVAL =                       130000000000000023010000f0501631
 POLYVAL_xor_NONCE  =            100000000000000023010000f0501631
 with MSBit cleared =            100000000000000023010000f0501631
-TAG =                           1e1fb157ee961567ee5a686a3ac66e74
+TAG =                           35c13a7848f4f53530aeff0176344e05
 AAD =                           01
-CT  =                           295cb156a7ccc66c9026829a26b08a92
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           a11196c1e68a743668290f75ed2f3bab
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000ee961567ee5a686a3ac66ef4
+                                35c13a7848f4f53530aeff0176344e85
 
 
 
@@ -627,7 +627,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -648,36 +648,36 @@ buffer of 3 blocks + LENBLK.
 POLYVAL =                       1c00000000000000460200203e78ef5b
 POLYVAL_xor_NONCE  =            1f00000000000000460200203e78ef5b
 with MSBit cleared =            1f00000000000000460200203e78ef5b
-TAG =                           c5558db375fc7fb253b477d990435e79
+TAG =                           900c57b053eac0245bb488688b3e0f5e
 AAD =                           01
-CT  =                           b1403a920a945105017054ccd7754e54
-                                7f471b9e42bd847f9ff2a6d5e1f72b92
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           c0a77a0fd04b3e590a924d938167ffe7
+                                659cd00ab7110b191376f8d8204e8f0d
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                0000000075fc7fb253b477d990435ef9
-                                0100000075fc7fb253b477d990435ef9
+                                900c57b053eac0245bb488688b3e0fde
+                                910c57b053eac0245bb488688b3e0fde
 
 
 
@@ -691,7 +691,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 48
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 3
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -714,38 +714,38 @@ buffer of 4 blocks + LENBLK.
 POLYVAL =                       1d000000000000006503c04c63ad386b
 POLYVAL_xor_NONCE  =            1e000000000000006503c04c63ad386b
 with MSBit cleared =            1e000000000000006503c04c63ad386b
-TAG =                           54538b4b90c4877f29632ec9441d9809
+TAG =                           12b64759e738e2d0cf178cba52a9f1eb
 AAD =                           01
-CT  =                           687c9c5846e8fde28bc1bde37dd15b80
-                                7ab731537d765e93f0d74bcac390ffbd
-                                b71ddb1af7505791ca74e87c697120b8
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           4e5ec0cac887e6fa1473f19c7978eec8
+                                a56c912d7a7505a35f96a41ad89bbf45
+                                2adaebf19add7e50cec3776b97d22e29
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                0000000090c4877f29632ec9441d9889
-                                0100000090c4877f29632ec9441d9889
-                                0200000090c4877f29632ec9441d9889
+                                12b64759e738e2d0cf178cba52a9f1eb
+                                13b64759e738e2d0cf178cba52a9f1eb
+                                14b64759e738e2d0cf178cba52a9f1eb
 
 
 
@@ -759,7 +759,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 64
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 4
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -784,40 +784,40 @@ buffer of 5 blocks + LENBLK.
 POLYVAL =                       1b000000000000008c841a01712a376e
 POLYVAL_xor_NONCE  =            18000000000000008c841a01712a376e
 with MSBit cleared =            18000000000000008c841a01712a376e
-TAG =                           49650717f842d3d193e3cc498e80f2c7
+TAG =                           4df7461010574a2c5a5f8c428c9a05a8
 AAD =                           01
-CT  =                           c17abb9e321814304f3844af4c90cb8e
-                                a89be09bd7a43a05021266c59a31609a
-                                3a2e7edf107c4c83d8370b36e52caca9
-                                de04c10dfd7eac3008852914cd9e900d
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           ed5596b2ac560cace49f593154576284
+                                7608cc1cd4be937778e4bc1542ce749c
+                                ef0de63e87dda60a0d58c39d40698b31
+                                c4bb87167c528a8db89975496c1586c7
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000f842d3d193e3cc498e80f2c7
-                                01000000f842d3d193e3cc498e80f2c7
-                                02000000f842d3d193e3cc498e80f2c7
-                                03000000f842d3d193e3cc498e80f2c7
+                                4df7461010574a2c5a5f8c428c9a05a8
+                                4ef7461010574a2c5a5f8c428c9a05a8
+                                4ff7461010574a2c5a5f8c428c9a05a8
+                                50f7461010574a2c5a5f8c428c9a05a8
 
 
 
@@ -831,7 +831,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -850,34 +850,34 @@ buffer of 2 blocks + LENBLK.
 POLYVAL =                       d8000000000000c048000000f050f665
 POLYVAL_xor_NONCE  =            db000000000000c048000000f050f665
 with MSBit cleared =            db000000000000c048000000f050f665
-TAG =                           0ee2162b829d1b8087a61dec79c2b4dd
+TAG =                           ff5ad2f9cbb36b1237cdbd63afb89d36
 AAD =                           010000000000000000000000
-CT  =                           7f25e1eb
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           7904ab1d
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000829d1b8087a61dec79c2b4dd
+                                ff5ad2f9cbb36b1237cdbd63afb89db6
 
 
 
@@ -891,7 +891,7 @@ padded_AAD_byte_len = 32
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 2
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -914,37 +914,37 @@ buffer of 4 blocks + LENBLK.
 POLYVAL =                       08010000000000c06b01c04c63ad9807
 POLYVAL_xor_NONCE  =            0b010000000000c06b01c04c63ad9807
 with MSBit cleared =            0b010000000000c06b01c04c63ad9807
-TAG =                           07e3ed3f0c192bb05b8de76bba7901aa
+TAG =                           19ff544d26d5f871b697767d0e1b7881
 AAD =                           01000000000000000000000000000000
                                 0200
-CT  =                           4f39b03d1cf9f45d74e756ff1a382004
-                                54b94c28
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           e6daeb5dd348a30936888ae23cc38783
+                                378c7134
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000000c192bb05b8de76bba7901aa
-                                010000000c192bb05b8de76bba7901aa
+                                19ff544d26d5f871b697767d0e1b7881
+                                1aff544d26d5f871b697767d0e1b7881
 
 
 
@@ -958,7 +958,7 @@ padded_AAD_byte_len = 32
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 2
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -981,37 +981,37 @@ buffer of 4 blocks + LENBLK.
 POLYVAL =                       64010000000000600701c04c63add8de
 POLYVAL_xor_NONCE  =            67010000000000600701c04c63add8de
 with MSBit cleared =            67010000000000600701c04c63add85e
-TAG =                           33f0e38bd6fb197ed4f7eaaea861d60b
+TAG =                           474ed2b302caba5f9460075bf577d777
 AAD =                           01000000000000000000000000000000
                                 02000000
-CT  =                           625534f47020a12f11754fbc86ed46cf
-                                41d0
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           1887531c24feb67e83067aa634f4106f
+                                9580
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
-                                c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+KEY_SCHEDULE (Encryption_Key)   01000000000000000000000000000000
+                                00000000000000000000000000000000
+                                63636363636363636363636363636363
+                                fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb
+                                6e6c6c6c0d0f0f0f6e6c6c6c0d0f0f0f
+                                2c8d8d8dd77676762c8d8d8dd7767676
+                                525454625f5b5b6d313737013c38380e
+                                c78a8a2610fcfc503c7171ddeb0707ab
+                                9f91368bc0ca6de6f1fd5ae7cdc562e9
+                                7a2c20386ad0dc6856a1adb5bda6aa1e
+                                ab3d44f16bf729179a0a73f057cf1119
+                                21a6a2ec4b767e841dd7d331a071792f
+                                288b5111437c7806d9760bf68eb91aef
+                                38f0003373867eb76e51ad86ce20d4a9
+                                dfc3829a9cbffa9c45c9f16acb70eb85
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000d6fb197ed4f7eaaea861d68b
-                                01000000d6fb197ed4f7eaaea861d68b
+                                474ed2b302caba5f9460075bf577d7f7
+                                484ed2b302caba5f9460075bf577d7f7
 
 
 
@@ -1025,7 +1025,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 0
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 0
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1033,9 +1033,9 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
-MSG =                           
-PADDED_AAD_and_MSG =            
+AAD =
+MSG =
+PADDED_AAD_and_MSG =
 LENBLK =                        00000000000000000000000000000000
 
 Computing POLYVAL on a
@@ -1043,30 +1043,39 @@ buffer of 0 blocks + LENBLK.
 POLYVAL =                       00000000000000000000000000000000
 POLYVAL_xor_NONCE  =            03000000000000000000000000000000
 with MSBit cleared =            03000000000000000000000000000000
-TAG =                           de1a5fcd85a5217d91d8b349ab9cd224
-AAD =                           
-CT  =                           
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           9f32298b78fb3a5e42a41f9ec395a8a0
+AAD =
+CT  =
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =
+
+TAG' =                          9f32298b78fb3a5e42a41f9ec395a8a0
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
@@ -1083,7 +1092,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1091,7 +1100,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           0100000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000004000000000000000
@@ -1101,34 +1110,43 @@ buffer of 1 blocks + LENBLK.
 POLYVAL =                       04000000000000809100000000283b1c
 POLYVAL_xor_NONCE  =            07000000000000809100000000283b1c
 with MSBit cleared =            07000000000000809100000000283b1c
-TAG =                           90d1e4ad87f53fbf3eb26c066193fdf3
-AAD =                           
-CT  =                           4b0619edd74c6a09
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           ca9daafe8fe6f1f97d5d37780af4d423
+AAD =
+CT  =                           403c53d07ec9ff2c
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 0100000000000000
+
+TAG' =                          ca9daafe8fe6f1f97d5d37780af4d423
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                0000000087f53fbf3eb26c066193fdf3
+                                ca9daafe8fe6f1f97d5d37780af4d4a3
 
 
 
@@ -1142,7 +1160,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1150,7 +1168,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           010000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000006000000000000000
@@ -1160,34 +1178,43 @@ buffer of 1 blocks + LENBLK.
 POLYVAL =                       0400000000000040d900000000283b1c
 POLYVAL_xor_NONCE  =            0700000000000040d900000000283b1c
 with MSBit cleared =            0700000000000040d900000000283b1c
-TAG =                           a42c36bcd7dd95273c5ded5a5ab0a8fc
-AAD =                           
-CT  =                           ea410b6727fe50357dc2c9f9
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           675861642d6f7c42973d470843868600
+AAD =
+CT  =                           0a5bcaa698b9cc0bc78383cf
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 010000000000000000000000
+
+TAG' =                          675861642d6f7c42973d470843868600
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000d7dd95273c5ded5a5ab0a8fc
+                                675861642d6f7c42973d470843868680
 
 
 
@@ -1201,7 +1228,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1209,7 +1236,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
 LENBLK =                        00000000000000008000000000000000
@@ -1219,34 +1246,43 @@ buffer of 1 blocks + LENBLK.
 POLYVAL =                       04000000000000002301000000283b1c
 POLYVAL_xor_NONCE  =            07000000000000002301000000283b1c
 with MSBit cleared =            07000000000000002301000000283b1c
-TAG =                           a86f26245dea30d23ec045223ef5851e
-AAD =                           
-CT  =                           d5d6c0782d45de97a027156334229387
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           255656d6213ddf996629d0c9db7c6332
+AAD =
+CT  =                           dfde1d2f762281c138f9d6d09203a270
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 01000000000000000000000000000000
+
+TAG' =                          255656d6213ddf996629d0c9db7c6332
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000005dea30d23ec045223ef5859e
+                                255656d6213ddf996629d0c9db7c63b2
 
 
 
@@ -1260,7 +1296,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1268,7 +1304,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
 PADDED_AAD_and_MSG =            01000000000000000000000000000000
@@ -1280,36 +1316,46 @@ buffer of 2 blocks + LENBLK.
 POLYVAL =                       010000000000000046020000f0507615
 POLYVAL_xor_NONCE  =            020000000000000046020000f0507615
 with MSBit cleared =            020000000000000046020000f0507615
-TAG =                           ac78c482d3499b26ae97bf353c2c1bdb
-AAD =                           
-CT  =                           cac82890d7f5a8330fa2f0f03701901a
-                                ed8a98666b42f74cc1887bd18964cf37
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           796e2bdd844cff0aac06f4b85a36d66b
+AAD =
+CT  =                           c680d1f9a3f2807ce9debce4bf670a98
+                                680619480f725d06ed91dbcbad65d07a
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 01000000000000000000000000000000
+                                02000000000000000000000000000000
+
+TAG' =                          796e2bdd844cff0aac06f4b85a36d66b
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000d3499b26ae97bf353c2c1bdb
-                                01000000d3499b26ae97bf353c2c1bdb
+                                796e2bdd844cff0aac06f4b85a36d6eb
+                                7a6e2bdd844cff0aac06f4b85a36d6eb
 
 
 
@@ -1323,7 +1369,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 48
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 3
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1331,7 +1377,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
                                 03000000000000000000000000000000
@@ -1345,38 +1391,49 @@ buffer of 3 blocks + LENBLK.
 POLYVAL =                       0e00000000000000650300203e788f7f
 POLYVAL_xor_NONCE  =            0d00000000000000650300203e788f7f
 with MSBit cleared =            0d00000000000000650300203e788f7f
-TAG =                           d47a0a762c2dea133c87aea50fb1c1b3
-AAD =                           
-CT  =                           bd562c8f8bbde467149c17a3f316fd2c
-                                8859c748760332d3296a5b233c4059e3
-                                e70a042dfc2b1812f484801a184b23ae
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           0457372a01c505a8718751a8f4c07958
+AAD =
+CT  =                           f5e1b0e6f6113e5d4a87ff54d0c6994e
+                                d1d702f63a63c9f132a7317bdb085dd8
+                                856fba3e70f5ebe2857de62946bd984b
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 01000000000000000000000000000000
+                                02000000000000000000000000000000
+                                03000000000000000000000000000000
+
+TAG' =                          0457372a01c505a8718751a8f4c07958
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000002c2dea133c87aea50fb1c1b3
-                                010000002c2dea133c87aea50fb1c1b3
-                                020000002c2dea133c87aea50fb1c1b3
+                                0457372a01c505a8718751a8f4c079d8
+                                0557372a01c505a8718751a8f4c079d8
+                                0657372a01c505a8718751a8f4c079d8
 
 
 
@@ -1390,7 +1447,7 @@ padded_AAD_byte_len = 0
 padded_MSG_byte_len = 64
 L1 blocks AAD(padded)  = 0
 L2 blocks MSG(padded)  = 4
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1398,7 +1455,7 @@ K1 = H =                        03000000000000000000000000000000
 K2 = K =                        01000000000000000000000000000000
                                 00000000000000000000000000000000
 NONCE =                         03000000000000000000000000000000
-AAD =                           
+AAD =
 MSG =                           01000000000000000000000000000000
                                 02000000000000000000000000000000
                                 03000000000000000000000000000000
@@ -1414,40 +1471,52 @@ buffer of 4 blocks + LENBLK.
 POLYVAL =                       0f000000000000008c04c04c63ad584f
 POLYVAL_xor_NONCE  =            0c000000000000008c04c04c63ad584f
 with MSBit cleared =            0c000000000000008c04c04c63ad584f
-TAG =                           15e4bd316b19caa3a3493a81a3e4153c
-AAD =                           
-CT  =                           d53e727defb0fe560c87f405ab19b1a2
-                                6fd85249324b974564c477b2eb4d4162
-                                943fa821946537d507e0713dcc556075
-                                220130acb5f3daa8dd46ee9af3b36642
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+TAG =                           0b188a792d0a940e66f50e37bf7f9810
+AAD =
+CT  =                           f32c3b7315f699ee449b3709fbd109fd
+                                c1726c48a8c48c5b19268372bc83919f
+                                9a717c2b7b042d33a75e4d0806c05f63
+                                5ad443dc419749efe8c4dec48f6d4254
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 01000000000000000000000000000000
+                                02000000000000000000000000000000
+                                03000000000000000000000000000000
+                                04000000000000000000000000000000
+
+TAG' =                          0b188a792d0a940e66f50e37bf7f9810
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000006b19caa3a3493a81a3e415bc
-                                010000006b19caa3a3493a81a3e415bc
-                                020000006b19caa3a3493a81a3e415bc
-                                030000006b19caa3a3493a81a3e415bc
+                                0b188a792d0a940e66f50e37bf7f9890
+                                0c188a792d0a940e66f50e37bf7f9890
+                                0d188a792d0a940e66f50e37bf7f9890
+                                0e188a792d0a940e66f50e37bf7f9890
 
 
 
@@ -1461,7 +1530,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1480,34 +1549,43 @@ buffer of 2 blocks + LENBLK.
 POLYVAL =                       130000000000008091000000f0501631
 POLYVAL_xor_NONCE  =            100000000000008091000000f0501631
 with MSBit cleared =            100000000000008091000000f0501631
-TAG =                           4cac1deb89734986b5f0546c661932e9
+TAG =                           6bc14bd99e1dc3de41371ee4012d84be
 AAD =                           01
-CT  =                           8e5a22875d5d692e
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           7b10160344fec6cb
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 0200000000000000
+
+TAG' =                          6bc14bd99e1dc3de41371ee4012d84be
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                0000000089734986b5f0546c661932e9
+                                6bc14bd99e1dc3de41371ee4012d84be
 
 
 
@@ -1521,7 +1599,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1540,34 +1618,43 @@ buffer of 2 blocks + LENBLK.
 POLYVAL =                       1300000000000040d9000000f0501631
 POLYVAL_xor_NONCE  =            1000000000000040d9000000f0501631
 with MSBit cleared =            1000000000000040d9000000f0501631
-TAG =                           42794bd56cd0b78ebdad8dc2c2c11720
+TAG =                           0707868473db0caa87ea08f1c44352c0
 AAD =                           01
-CT  =                           ed921994f8d27aad941bfb6f
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           75ffe5c8403db5fb479bc58b
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 020000000000000000000000
+
+TAG' =                          0707868473db0caa87ea08f1c44352c0
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000006cd0b78ebdad8dc2c2c117a0
+                                0707868473db0caa87ea08f1c44352c0
 
 
 
@@ -1581,7 +1668,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1600,34 +1687,43 @@ buffer of 2 blocks + LENBLK.
 POLYVAL =                       130000000000000023010000f0501631
 POLYVAL_xor_NONCE  =            100000000000000023010000f0501631
 with MSBit cleared =            100000000000000023010000f0501631
-TAG =                           1e1fb157ee961567ee5a686a3ac66e74
+TAG =                           35c13a7848f4f53530aeff0176344e05
 AAD =                           01
-CT  =                           295cb156a7ccc66c9026829a26b08a92
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           a11196c1e68a743668290f75ed2f3bab
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 02000000000000000000000000000000
+
+TAG' =                          35c13a7848f4f53530aeff0176344e05
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000ee961567ee5a686a3ac66ef4
+                                35c13a7848f4f53530aeff0176344e85
 
 
 
@@ -1641,7 +1737,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1662,36 +1758,46 @@ buffer of 3 blocks + LENBLK.
 POLYVAL =                       1c00000000000000460200203e78ef5b
 POLYVAL_xor_NONCE  =            1f00000000000000460200203e78ef5b
 with MSBit cleared =            1f00000000000000460200203e78ef5b
-TAG =                           c5558db375fc7fb253b477d990435e79
+TAG =                           900c57b053eac0245bb488688b3e0f5e
 AAD =                           01
-CT  =                           b1403a920a945105017054ccd7754e54
-                                7f471b9e42bd847f9ff2a6d5e1f72b92
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           c0a77a0fd04b3e590a924d938167ffe7
+                                659cd00ab7110b191376f8d8204e8f0d
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 02000000000000000000000000000000
+                                03000000000000000000000000000000
+
+TAG' =                          900c57b053eac0245bb488688b3e0f5e
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                0000000075fc7fb253b477d990435ef9
-                                0100000075fc7fb253b477d990435ef9
+                                900c57b053eac0245bb488688b3e0fde
+                                910c57b053eac0245bb488688b3e0fde
 
 
 
@@ -1705,7 +1811,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 48
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 3
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1728,38 +1834,49 @@ buffer of 4 blocks + LENBLK.
 POLYVAL =                       1d000000000000006503c04c63ad386b
 POLYVAL_xor_NONCE  =            1e000000000000006503c04c63ad386b
 with MSBit cleared =            1e000000000000006503c04c63ad386b
-TAG =                           54538b4b90c4877f29632ec9441d9809
+TAG =                           12b64759e738e2d0cf178cba52a9f1eb
 AAD =                           01
-CT  =                           687c9c5846e8fde28bc1bde37dd15b80
-                                7ab731537d765e93f0d74bcac390ffbd
-                                b71ddb1af7505791ca74e87c697120b8
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           4e5ec0cac887e6fa1473f19c7978eec8
+                                a56c912d7a7505a35f96a41ad89bbf45
+                                2adaebf19add7e50cec3776b97d22e29
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 02000000000000000000000000000000
+                                03000000000000000000000000000000
+                                04000000000000000000000000000000
+
+TAG' =                          12b64759e738e2d0cf178cba52a9f1eb
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                0000000090c4877f29632ec9441d9889
-                                0100000090c4877f29632ec9441d9889
-                                0200000090c4877f29632ec9441d9889
+                                12b64759e738e2d0cf178cba52a9f1eb
+                                13b64759e738e2d0cf178cba52a9f1eb
+                                14b64759e738e2d0cf178cba52a9f1eb
 
 
 
@@ -1773,7 +1890,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 64
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 4
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1798,40 +1915,52 @@ buffer of 5 blocks + LENBLK.
 POLYVAL =                       1b000000000000008c841a01712a376e
 POLYVAL_xor_NONCE  =            18000000000000008c841a01712a376e
 with MSBit cleared =            18000000000000008c841a01712a376e
-TAG =                           49650717f842d3d193e3cc498e80f2c7
+TAG =                           4df7461010574a2c5a5f8c428c9a05a8
 AAD =                           01
-CT  =                           c17abb9e321814304f3844af4c90cb8e
-                                a89be09bd7a43a05021266c59a31609a
-                                3a2e7edf107c4c83d8370b36e52caca9
-                                de04c10dfd7eac3008852914cd9e900d
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           ed5596b2ac560cace49f593154576284
+                                7608cc1cd4be937778e4bc1542ce749c
+                                ef0de63e87dda60a0d58c39d40698b31
+                                c4bb87167c528a8db89975496c1586c7
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 02000000000000000000000000000000
+                                03000000000000000000000000000000
+                                04000000000000000000000000000000
+                                05000000000000000000000000000000
+
+TAG' =                          4df7461010574a2c5a5f8c428c9a05a8
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000f842d3d193e3cc498e80f2c7
-                                01000000f842d3d193e3cc498e80f2c7
-                                02000000f842d3d193e3cc498e80f2c7
-                                03000000f842d3d193e3cc498e80f2c7
+                                4df7461010574a2c5a5f8c428c9a05a8
+                                4ef7461010574a2c5a5f8c428c9a05a8
+                                4ff7461010574a2c5a5f8c428c9a05a8
+                                50f7461010574a2c5a5f8c428c9a05a8
 
 
 
@@ -1845,7 +1974,7 @@ padded_AAD_byte_len = 16
 padded_MSG_byte_len = 16
 L1 blocks AAD(padded)  = 1
 L2 blocks MSG(padded)  = 1
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1864,34 +1993,43 @@ buffer of 2 blocks + LENBLK.
 POLYVAL =                       d8000000000000c048000000f050f665
 POLYVAL_xor_NONCE  =            db000000000000c048000000f050f665
 with MSBit cleared =            db000000000000c048000000f050f665
-TAG =                           0ee2162b829d1b8087a61dec79c2b4dd
+TAG =                           ff5ad2f9cbb36b1237cdbd63afb89d36
 AAD =                           010000000000000000000000
-CT  =                           7f25e1eb
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           7904ab1d
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 02000000
+
+TAG' =                          ff5ad2f9cbb36b1237cdbd63afb89d36
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000829d1b8087a61dec79c2b4dd
+                                ff5ad2f9cbb36b1237cdbd63afb89db6
 
 
 
@@ -1905,7 +2043,7 @@ padded_AAD_byte_len = 32
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 2
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1928,37 +2066,47 @@ buffer of 4 blocks + LENBLK.
 POLYVAL =                       08010000000000c06b01c04c63ad9807
 POLYVAL_xor_NONCE  =            0b010000000000c06b01c04c63ad9807
 with MSBit cleared =            0b010000000000c06b01c04c63ad9807
-TAG =                           07e3ed3f0c192bb05b8de76bba7901aa
+TAG =                           19ff544d26d5f871b697767d0e1b7881
 AAD =                           01000000000000000000000000000000
                                 0200
-CT  =                           4f39b03d1cf9f45d74e756ff1a382004
-                                54b94c28
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           e6daeb5dd348a30936888ae23cc38783
+                                378c7134
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 03000000000000000000000000000000
+                                04000000
+
+TAG' =                          19ff544d26d5f871b697767d0e1b7881
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                000000000c192bb05b8de76bba7901aa
-                                010000000c192bb05b8de76bba7901aa
+                                19ff544d26d5f871b697767d0e1b7881
+                                1aff544d26d5f871b697767d0e1b7881
 
 
 
@@ -1972,7 +2120,7 @@ padded_AAD_byte_len = 32
 padded_MSG_byte_len = 32
 L1 blocks AAD(padded)  = 2
 L2 blocks MSG(padded)  = 2
-                                            BYTES ORDER         
+                                            BYTES ORDER
                                 LSB--------------------------MSB
                                 00010203040506070809101112131415
                                 --------------------------------
@@ -1995,34 +2143,44 @@ buffer of 4 blocks + LENBLK.
 POLYVAL =                       64010000000000600701c04c63add8de
 POLYVAL_xor_NONCE  =            67010000000000600701c04c63add8de
 with MSBit cleared =            67010000000000600701c04c63add85e
-TAG =                           33f0e38bd6fb197ed4f7eaaea861d60b
+TAG =                           474ed2b302caba5f9460075bf577d777
 AAD =                           01000000000000000000000000000000
                                 02000000
-CT  =                           625534f47020a12f11754fbc86ed46cf
-                                41d0
-Encryption_Key =                d77cdb05a40231d52ec7ef3b115a4259
+CT  =                           1887531c24feb67e83067aa634f4106f
+                                9580
+Encryption_Key =                5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
 
+Performing Decryption and
+Authentication:
+
+Decrypted MSG =                 03000000000000000000000000000000
+                                0400
+
+TAG' =                          474ed2b302caba5f9460075bf577d777
+
+TAG comparison PASSED!!!
+
 ***************************
-         APPENDIX          
+         APPENDIX
 ***************************
-KEY_SCHEDULE (Encryption_Key)   d77cdb05a40231d52ec7ef3b115a4259
+KEY_SCHEDULE (Encryption_Key)   5f377914db056de594bd23b0f07076be
                                 c88735cffb99fd5cd4c805dcf487f5ae
-                                c19a3fba65980e6f4b5fe1545a05a30d
-                                76ec3f188d75c24459bdc798ad3a3236
-                                43b93a2f262134406d7ed514377b7619
-                                eccd07cc61b8c58838050210953f3026
-                                32bdcd05149cf94579e22c514e995a48
-                                c323b99ea29b7c169a9e7e060fa14e20
-                                08927a731c0e833665ecaf672b75f52f
-                                32be5f8b9025239d0abb5d9b051a13bb
-                                baef9018a6e1132ec30dbc49e8784966
-                                a90264b839274725339c1abe36860905
-                                deeefb1d780fe833bb02547a537a1d1c
-                                44d8c0247dff87014e639dbf78e594ba
-                                47cc0fa13fc3e79284c1b3e8d7bbaef4
+                                49d19dab92d4f04e0669d3fef619a540
+                                8a5333c671cace9aa502cb4651853ee8
+                                dc63067a4eb7f63448de25cabec7808a
+                                2495feb8555f3022f05dfb64a1d8c58c
+                                b9c56248f772947cbfacb1b6016b313c
+                                58ea39530db50971fde8f2155c303799
+                                b55f8c02422d187efd81a9c8fcea98f4
+                                e86d7fece5d8769d183084884400b311
+                                c6320e19841f1667799ebfaf8574275b
+                                7fffb3d59a27c548821741c0c617f2d1
+                                16bb30ad92a426caeb3a99656e4ebe3e
+                                e0d01d677af7d82ff8e099ef3ef76b3e
+                                3ec4821fac60a4d5475a3db02914838e
 
 CTRBLKS (with MSbit set to 1)
 
-                                00000000d6fb197ed4f7eaaea861d68b
-                                01000000d6fb197ed4f7eaaea861d68b
+                                474ed2b302caba5f9460075bf577d7f7
+                                484ed2b302caba5f9460075bf577d7f7


### PR DESCRIPTION
Commit 99f99085ddac5d15c7 updated the code and referenced
the new test vector test files output_add_info_be{128,256}.txt
but did not add them.

This patch adds the new test vectors (extracted from the xml).

The tests used to fail. Now they pass:

$ go test -v
=== RUN   TestToFromBytes
--- PASS: TestToFromBytes (0.00s)
=== RUN   TestFieldOps
--- PASS: TestFieldOps (0.00s)
=== RUN   TestPolyval
--- PASS: TestPolyval (0.00s)
=== RUN   TestHelloWorld
--- PASS: TestHelloWorld (0.00s)
=== RUN   TestAgainstVectors128
--- PASS: TestAgainstVectors128 (0.00s)
=== RUN   TestAgainstVectors256
--- PASS: TestAgainstVectors256 (0.00s)
PASS
ok      github.com/agl/gcmsiv   0.006s
