### PR TITLE
Prevent "constant overflows int" on systems where int is int32

### DIFF
--- a/gcmsiv.go
+++ b/gcmsiv.go
@@ -266,9 +266,9 @@ func polyval(hBytes [16]byte, input []byte) [16]byte {
 }
 
 const (
-	maxPlaintextLen  = 1 << 36
-	maxCiphertextLen = maxPlaintextLen + 16
-	maxADLen         = (1 << 61) - 1
+	maxPlaintextLen int64  = 1 << 36
+	maxCiphertextLen int64 = maxPlaintextLen + 16
+	maxADLen int64         = (1 << 61) - 1
 )
 
 type GCMSIV struct {
@@ -452,11 +452,11 @@ func (ctx *GCMSIV) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 		log("Nonce", nonce)
 	}
 
-	if len(plaintext) > maxPlaintextLen {
+	if int64(len(plaintext)) > maxPlaintextLen {
 		panic("gcmsiv: plaintext too large")
 	}
 
-	if len(additionalData) > maxADLen {
+	if int64(len(additionalData)) > maxADLen {
 		panic("gcmsiv: additional data too large")
 	}
 
@@ -472,11 +472,11 @@ func (ctx *GCMSIV) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 }
 
 func (ctx GCMSIV) Open(dst, nonce, ciphertext, additionalData []byte) (out []byte, err error) {
-	if len(additionalData) > maxADLen {
+	if int64(len(additionalData)) > maxADLen {
 		return nil, errors.New("gcmsiv: bad ciphertext length")
 	}
 
-	if len(ciphertext) < 16 || len(ciphertext) > maxCiphertextLen {
+	if len(ciphertext) < 16 || int64(len(ciphertext)) > maxCiphertextLen {
 		return nil, errors.New("gcmsiv: bad ciphertext length")
 	}
 


### PR DESCRIPTION
I made this commit, so I might as well create a pull request.
This change makes the implementation usable on 32 bit systems, because int has only 32 bit on them.

Feel free to decline the request, if it is not welcome.